### PR TITLE
Update sorting indicator icon

### DIFF
--- a/frontend/components/Table/Table.tsx
+++ b/frontend/components/Table/Table.tsx
@@ -101,8 +101,8 @@ const Table = ({
                       >
                         {flexRender(header.column.columnDef.header, header.getContext())}
                         {{
-                          asc: " 🔼",
-                          desc: " 🔽",
+                          asc: " ▲",
+                          desc: " ▼",
                         }[header.column.getIsSorted() as string] ?? null}
                       </div>
                     )}


### PR DESCRIPTION
Updated table sorting icons to look more modern and match the site's aesthetic

Before:
![image](https://github.com/avgupta456/statbotics/assets/105139789/5d4833dd-7fce-4e8c-abb9-d6504220f9b5)


After:
![image](https://github.com/avgupta456/statbotics/assets/105139789/90101fc4-3f4b-41f7-b581-333ef4b0a5e5)

