### PR TITLE
Update fouls calculation for 2025

### DIFF
--- a/backend/src/db/models/year.py
+++ b/backend/src/db/models/year.py
@@ -221,8 +221,11 @@ class Year(_Year, Model):
         # Only refresh DB if these change (during 1 min partial update)
         return "_".join([str(self.year), str(self.count)])
 
-    def get_foul_rate(self: "Year") -> float:
-        return (self.foul_mean or 0) / (self.no_foul_mean or 1)
+    def get_expected_fouls(self: "Year", score: float) -> float:
+        if self.year == 2025:
+            return -0.0116 * score + 4.33
+        else:
+            return score * (self.foul_mean or 0) / (self.no_foul_mean or 1)
 
     def get_mean_components(self: "Year") -> Any:
         if self.year < 2016:

--- a/backend/src/models/epa/main.py
+++ b/backend/src/models/epa/main.py
@@ -138,9 +138,8 @@ class EPA(Model):
         norm_diff = (red_score - blue_score) / self.year_obj.score_sd
         win_prob = 1 / (1 + 10 ** (self.k * norm_diff))
 
-        foul_rate = self.year_obj.get_foul_rate()
-        red_score_with_fouls = red_score * (1 + foul_rate)
-        blue_score_with_fouls = blue_score * (1 + foul_rate)
+        red_score_with_fouls = red_score + self.year_obj.get_expected_fouls(red_score)
+        blue_score_with_fouls = blue_score + self.year_obj.get_expected_fouls(blue_score)
         red_pred = AlliancePred(
             red_score_with_fouls, breakdowns[0], rp_1s[0], rp_2s[0], rp_3s[0]
         )


### PR DESCRIPTION
I noticed that the foul point calculation assumed fouls scaled linearly with the no foul score, while on the real data there is a negative correlation. I fitted a line to match data from this year and it should give more accurate results, especially for high scoring matches.

Also note that I haven't actually tested the code.