### PR TITLE
Reduced redundant calls to google storage

### DIFF
--- a/frontend/src/pagesContent/team/main.tsx
+++ b/frontend/src/pagesContent/team/main.tsx
@@ -14,6 +14,10 @@ import SummaryTabs from "./summaryTabs";
 import Tabs from "./tabs";
 
 const PageContent = ({ team, paramYear }: { team: number; paramYear: number }) => {
+  if (isNaN(team)) {
+    return <NotFound type="Team" />;
+  }
+
   const [prevYear, _setPrevYear] = useState(paramYear);
   const [year, _setYear] = useState(paramYear);
 
@@ -47,7 +51,7 @@ const PageContent = ({ team, paramYear }: { team: number; paramYear: number }) =
     if (year >= 2002 && year <= CURR_YEAR) {
       _getTeamYearDataForYear(team, year);
     }
-  }, [team, year, teamYearDataDict]);
+  }, [team, year]);
 
   const teamYearData = teamYearDataDict?.[year];
   const fallbackTeamYearData = teamYearDataDict?.[prevYear];


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/06486f4c-702d-4413-becb-25cbf494f1f1)
![image](https://github.com/user-attachments/assets/76c40b94-d455-4bc2-94e1-dfb4ebdfdc56)

Removed redundancies when fetching data from google storage.

This can be pushed even further by dropping the need to load `team_years/2025`.
If you derive a teams win/loss by the data from all their events, same for epa and what not you could go without the team years info.

The expiration systems also seems to bypassed for some of this fetched data.