### PR TITLE
Update play button to link directly to YouTube URL

### DIFF
--- a/frontend/src/components/MatchTable.tsx
+++ b/frontend/src/components/MatchTable.tsx
@@ -54,14 +54,13 @@ const MatchRow = ({
   const Video = () => (
     <div className="w-16 h-full flex justify-center items-center border-r border-b border-gray-300">
       {match.video && (
-        <Link
-          href={`/match/${match.key}`}
-          // href={`https://www.youtube.com/watch?v=${match.video}`}
-          // rel="noreferrer noopener"
-          // target="_blank"
+        <a
+          href={`https://www.youtube.com/watch?v=${match.video}`}
+          rel="noreferrer noopener"
+          target="_blank"
         >
           <BsPlayCircle className="text-blue-600 hover:text-blue-700 cursor-pointer" />
-        </Link>
+        </a>
       )}
     </div>
   );


### PR DESCRIPTION
Updates the play button in match tables to link directly to the match YouTube video, instead of just taking you to the match page.