### PR TITLE
feat(mcp): add statbotics-mcp server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Statbotics is an open-source data analytics platform for the FIRST Robotics Comp
 | `frontend/` | Next.js 13 frontend — the active, deployed website | See `frontend/CLAUDE.md` |
 | `new/frontend/` | **Paused** Next.js 14 rewrite — do not read or modify unless explicitly asked | — |
 | `api/` | `statbotics` Python package published to PyPI | See `api/CLAUDE.md` |
+| `mcp/` | `statbotics-mcp` MCP server wrapping the public API for LLM clients | See `mcp/CLAUDE.md` |
 | `scripts/` | Jupyter notebooks for EPA model analysis and API demos | See `scripts/CLAUDE.md` |
 
 ## Working Style

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ print(sb.get_team(254))
 
 More details are available [here](https://www.statbotics.io/api/python).
 
+## MCP Server
+
+An MCP (Model Context Protocol) server is also shipped in this repo under [`mcp/`](./mcp), exposing the public Statbotics API as MCP tools so any MCP-aware LLM client (Claude Desktop, VS Code, Cursor, etc.) can query team, year, event, and match data directly. It is published to PyPI as [`statbotics-mcp`](https://pypi.org/project/statbotics-mcp/) and runnable from a clone. See [`mcp/README.md`](./mcp/README.md) for client config snippets.
+
 ## Website
 
 The website is written in NextJS, TypeScript, and TailwindCSS and aims to make EPA statistics accessible and actionable. The website includes EPA tables (with location filters, sortable columns), figures (Bubble charts, line graphs, bar graphs, etc.), live event simulation (including ranking points and tiebreakers), match breakdowns (with component predictions), and so much more. Check it out at [statbotics.io](https://www.statbotics.io)!

--- a/docs/brainstorms/2026-04-27-statbotics-mcp-server-brainstorm.md
+++ b/docs/brainstorms/2026-04-27-statbotics-mcp-server-brainstorm.md
@@ -1,0 +1,49 @@
+---
+date: 2026-04-27
+topic: statbotics-mcp-server
+---
+
+# Statbotics MCP Server
+
+## What We're Building
+
+An MCP (Model Context Protocol) server, shipped in this repo under a new top-level `mcp/` directory, that exposes the public Statbotics REST API (`https://api.statbotics.io/v3`) as MCP tools. The server is a thin wrapper that delegates HTTP work to the existing `statbotics` Python package (in `api/`), so all URL handling, caching, validation, and field filtering stay in one place.
+
+The server is intended to be runnable directly from a fresh clone for repo users, and also publishable to PyPI as `statbotics-mcp` so end users can launch it with `uvx statbotics-mcp` from any MCP client.
+
+## Why This Approach
+
+- **Reuse over duplication.** The `statbotics` package already wraps the public API with caching, validation, and the canonical method surface — building on top avoids drift.
+- **Public API only.** The MCP server never talks to the backend directly; it only hits `api.statbotics.io`, matching how external users consume Statbotics today.
+- **Thin 1:1 tool mapping.** Mirrors the `Statbotics` class methods so the MCP tool surface tracks the documented Python API. No opinionated curation to maintain.
+- **FastMCP** keeps boilerplate low and gives stdio + HTTP/SSE transports out of the box.
+
+## Key Decisions
+
+- **Language/runtime:** Python, importing the `statbotics` package as a dependency.
+- **Location:** New top-level `mcp/` directory with its own `pyproject.toml`. Independent of `api/` packaging.
+- **Transports:** Both stdio (default) and HTTP/SSE (opt-in via CLI flag).
+- **Tool surface:** Thin 1:1 mapping — one MCP tool per public method on `Statbotics`:
+  - `get_team`, `get_teams`
+  - `get_year`, `get_years`
+  - `get_team_year`, `get_team_years`
+  - `get_event`, `get_events`
+  - `get_team_event`, `get_team_events`
+  - `get_match`, `get_matches`
+  - `get_team_match`, `get_team_matches`
+- **SDK:** FastMCP.
+- **Resources/prompts:** None for v1 — tools only.
+- **Distribution:** Runnable from clone (`python -m statbotics_mcp`) AND published to PyPI as `statbotics-mcp` (`uvx statbotics-mcp`).
+- **Supporting infra:** README with copy-paste client config snippets (Claude Desktop, VS Code, Cursor). No CI workflow or Dockerfile in v1.
+
+## Open Questions
+
+- Package/module name on disk: `statbotics_mcp` vs `statbotics-mcp` vs nested under `statbotics.mcp`. (Leaning `statbotics_mcp` as a sibling project.)
+- Minimum Python version — `statbotics` declares `^3.8`; FastMCP typically requires ≥3.10. Likely set MCP server to `>=3.10`.
+- HTTP/SSE bind address/port defaults and whether to require an explicit `--http` flag.
+- How to surface the upstream API base URL — fixed to `https://api.statbotics.io/v3`, or overridable via env var (e.g. `STATBOTICS_API_URL`) for local backend testing?
+- Tool docstrings: auto-generate from `Statbotics` method docstrings, or hand-author for LLM clarity?
+
+## Next Steps
+
+→ Switch out of plan mode (or run a planning pass) to produce an implementation plan covering directory layout, `pyproject.toml`, tool definitions, transport wiring, README config snippets, and PyPI publish steps.

--- a/mcp/.dockerignore
+++ b/mcp/.dockerignore
@@ -1,0 +1,11 @@
+.venv/
+**/__pycache__/
+**/*.pyc
+.pytest_cache/
+tests/
+*.egg-info/
+dist/
+build/
+.git/
+.gitignore
+CLAUDE.md

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.venv/
+dist/
+build/

--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working in the `mcp/` directory.
+
+## Overview
+
+The `statbotics-mcp` package is an MCP (Model Context Protocol) server that exposes the public Statbotics API as MCP tools for LLM clients (Claude Desktop, VS Code, Cursor, etc.). It is a thin wrapper — it always targets the public production API at `https://api.statbotics.io/v3` via the existing [`statbotics`](../api) Python package, and adds no business logic of its own.
+
+## Commands (run from `mcp/`)
+
+```bash
+pip install -e .              # Install for development (or: poetry install)
+pytest                        # Run tests
+python -m statbotics_mcp      # Run the server over stdio (default MCP transport)
+python -m statbotics_mcp --http --host 127.0.0.1 --port 8000   # Run over streamable-HTTP
+```
+
+## Structure
+
+- **`statbotics_mcp/server.py`** — `FastMCP("statbotics")` instance with one `@mcp.tool()` per public method on the `Statbotics` class. Tool descriptions are pulled from the underlying method docstrings via `Statbotics.<method>.__doc__`.
+- **`statbotics_mcp/client.py`** — Lazily-initialized singleton `Statbotics()` instance. Honors the `STATBOTICS_API_URL` env var to override the base URL (useful for local backend testing). `reset_client()` exposed for tests.
+- **`statbotics_mcp/cli.py`** — `argparse` entry point. `--http` switches from stdio to streamable-HTTP transport; `--host` / `--port` apply only to HTTP mode.
+- **`statbotics_mcp/__main__.py`** — Enables `python -m statbotics_mcp`.
+- **`tests/test_server.py`** — Tool-registration assertions (all 14 tools), description sanity checks, schema spot-checks, and behavior tests using a stubbed `Statbotics` instance set via `monkeypatch`.
+
+## Key Behaviors
+
+- **Tool surface mirrors `Statbotics` 1:1** — 14 tools matching `get_team`, `get_teams`, `get_year`, `get_years`, `get_team_year`, `get_team_years`, `get_event`, `get_events`, `get_team_event`, `get_team_events`, `get_match`, `get_matches`, `get_team_match`, `get_team_matches`. Add a new tool here whenever a method is added to the wrapper.
+- **Defaults match the wrapper** — including `fields=["all"]` and per-method `limit` defaults (200 for `get_matches`, 100 elsewhere).
+- **Errors propagate naturally** — `UserWarning` and `ValueError` raised by the wrapper become MCP tool errors via FastMCP's default exception handling. No custom wrapping.
+- **No backend access** — this server only talks to the public REST API; it does not import `backend/`.
+- **Python 3.11+** to match the repo's backend CI and FastMCP's runtime requirement.
+
+## Publishing
+
+Update `version` in `pyproject.toml`, then `poetry publish --build` (same flow as `api/`). The console-script entry point is `statbotics-mcp = statbotics_mcp.cli:main`, so end users can run `uvx statbotics-mcp`.

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY statbotics_mcp ./statbotics_mcp
+
+RUN pip install .
+
+EXPOSE 8000
+
+ENTRYPOINT ["statbotics-mcp"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,212 @@
+# statbotics-mcp
+
+An [MCP](https://modelcontextprotocol.io) (Model Context Protocol) server for
+the public [Statbotics](https://statbotics.io) API. It exposes the same surface
+as the [`statbotics`](https://pypi.org/project/statbotics/) Python package —
+team, year, event, and match EPA data for FIRST Robotics Competition (FRC) — as
+MCP tools that any MCP-aware LLM client can call.
+
+The server always targets the public production API at
+`https://api.statbotics.io/v3`. It is published as a convenience for users of
+this repo and for end users who want a ready-made MCP integration.
+
+## Install
+
+### From PyPI (recommended for end users)
+
+```bash
+uvx statbotics-mcp           # one-off run, no install
+# or
+pipx install statbotics-mcp
+```
+
+### From a clone (for repo contributors)
+
+```bash
+cd mcp
+pip install -e .
+python -m statbotics_mcp
+```
+
+Requires Python **3.11+**.
+
+### Docker (no Python toolchain required)
+
+If `statbotics-mcp` is not on PyPI yet — or you'd rather not install Python at
+all — build the image from the cloned repo:
+
+```bash
+cd mcp
+docker build -t statbotics-mcp .
+```
+
+Then run it over stdio:
+
+```bash
+docker run -i --rm statbotics-mcp
+```
+
+Or in HTTP mode:
+
+```bash
+docker run --rm -p 8000:8000 statbotics-mcp --http --host 0.0.0.0 --port 8000
+```
+
+## Run
+
+### stdio (default — used by Claude Desktop, VS Code, Cursor, etc.)
+
+```bash
+statbotics-mcp
+# or
+python -m statbotics_mcp
+```
+
+### Streamable-HTTP (for remote/hosted use)
+
+```bash
+statbotics-mcp --http --host 127.0.0.1 --port 8000
+```
+
+## Client configuration
+
+All snippets below configure the server over **stdio** — the right choice
+when the MCP client and server live on the same machine. Use HTTP only when
+you genuinely need a remote/hosted deployment (see [Run](#run)).
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "statbotics": {
+      "command": "uvx",
+      "args": ["statbotics-mcp"]
+    }
+  }
+}
+```
+
+### VS Code
+
+Add to `.vscode/mcp.json` (or your user-level MCP config):
+
+```json
+{
+  "servers": {
+    "statbotics": {
+      "command": "uvx",
+      "args": ["statbotics-mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "statbotics": {
+      "command": "uvx",
+      "args": ["statbotics-mcp"]
+    }
+  }
+}
+```
+
+### GitHub Copilot CLI
+
+Either run `/mcp add` inside an interactive `copilot` session and fill in the
+fields, or edit `~/.copilot/mcp-config.json` directly (override the location
+with the `COPILOT_HOME` environment variable):
+
+```json
+{
+  "mcpServers": {
+    "statbotics": {
+      "type": "local",
+      "command": "uvx",
+      "args": ["statbotics-mcp"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+After saving, run `/mcp` inside Copilot CLI to confirm the `statbotics` server
+is listed and its tools are enabled.
+
+If you installed from a clone instead of PyPI, swap `command` / `args` for
+something like:
+
+```json
+{
+  "command": "python",
+  "args": ["-m", "statbotics_mcp"]
+}
+```
+
+### Using the Docker image
+
+If you built the Docker image (see [Docker](#docker-no-python-toolchain-required)
+above), every client config above works by swapping `command` / `args` for:
+
+```json
+{
+  "command": "docker",
+  "args": ["run", "-i", "--rm", "statbotics-mcp"]
+}
+```
+
+The `-i` flag is required so the container keeps stdin open for the MCP
+stdio transport. To point at a non-default backend, append
+`-e STATBOTICS_API_URL=...` before the image name.
+
+## Tools
+
+The server exposes a 1:1 mapping of the methods on the
+[`Statbotics`](../api/statbotics/main.py) Python client:
+
+| Tool | Description |
+| ---- | ----------- |
+| `get_team` | Retrieve a single team's metadata and EPA stats. |
+| `get_teams` | List teams, filterable by country/state/district/active, sortable by metric. |
+| `get_year` | Retrieve aggregate stats for a specific season. |
+| `get_years` | List per-year aggregates, sortable by metric. |
+| `get_team_year` | A team's stats in a specific year. |
+| `get_team_years` | List (team, year) pairs with filtering and sorting. |
+| `get_event` | Retrieve a single event by key (e.g. `2019cur`). |
+| `get_events` | List events, filterable by year/location/type/week. |
+| `get_team_event` | A team's stats at a specific event. |
+| `get_team_events` | List (team, event) pairs with filtering and sorting. |
+| `get_match` | Retrieve a single match by key (e.g. `2019cur_qm1`). |
+| `get_matches` | List matches, filterable by team/year/event/week/elims. |
+| `get_team_match` | A team's stats in a specific match. |
+| `get_team_matches` | List (team, match) pairs with filtering and sorting. |
+
+All tools accept a `fields` parameter (defaults to `["all"]`) that selects
+which response fields to return, and plural tools accept `limit`, `offset`,
+`metric`, and `ascending` for paging and sorting.
+
+## Configuration
+
+| Environment variable | Purpose |
+| -------------------- | ------- |
+| `STATBOTICS_API_URL` | Override the API base URL (default `https://api.statbotics.io/v3`). Useful for pointing at a locally-running backend. |
+
+## Development
+
+```bash
+cd mcp
+pip install -e .[dev]   # or: poetry install
+pytest
+```
+
+## License
+
+MIT — same as the parent repository.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.poetry]
+name = "statbotics-mcp"
+version = "0.1.0"
+description = "MCP (Model Context Protocol) server for the public Statbotics API"
+authors = ["Statbotics contributors"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/avgupta456/statbotics"
+homepage = "https://statbotics.io"
+keywords = ["FIRST", "robotics", "FRC", "EPA", "MCP", "statbotics"]
+packages = [{ include = "statbotics_mcp" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+statbotics = "^3.0.0"
+fastmcp = "^2.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+
+[tool.poetry.scripts]
+statbotics-mcp = "statbotics_mcp.cli:main"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88

--- a/mcp/statbotics_mcp/__init__.py
+++ b/mcp/statbotics_mcp/__init__.py
@@ -1,0 +1,4 @@
+from .server import mcp
+
+__version__ = "0.1.0"
+__all__ = ["mcp", "__version__"]

--- a/mcp/statbotics_mcp/__main__.py
+++ b/mcp/statbotics_mcp/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mcp/statbotics_mcp/cli.py
+++ b/mcp/statbotics_mcp/cli.py
@@ -1,0 +1,51 @@
+"""Command-line entry point for the Statbotics MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional, Sequence
+
+from .server import mcp
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="statbotics-mcp",
+        description=(
+            "MCP server for the public Statbotics API. "
+            "Defaults to stdio transport for use with local MCP clients "
+            "(Claude Desktop, VS Code, Cursor). "
+            "Pass --http to expose the server over HTTP/SSE instead."
+        ),
+    )
+    parser.add_argument(
+        "--http",
+        action="store_true",
+        help="Run a streamable-HTTP server instead of speaking MCP over stdio.",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind when --http is used (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind when --http is used (default: 8000).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.http:
+        mcp.run(transport="http", host=args.host, port=args.port)
+    else:
+        mcp.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp/statbotics_mcp/client.py
+++ b/mcp/statbotics_mcp/client.py
@@ -1,0 +1,39 @@
+"""Singleton Statbotics HTTP client used by all MCP tools.
+
+The MCP server always targets the public API at ``https://api.statbotics.io/v3``.
+The base URL can be overridden by setting the ``STATBOTICS_API_URL`` environment
+variable, which is useful for pointing at a locally-running backend.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from statbotics import Statbotics
+
+_client: Optional[Statbotics] = None
+
+
+def get_client() -> Statbotics:
+    """Return a process-wide :class:`Statbotics` instance.
+
+    The instance is created lazily on first call. If ``STATBOTICS_API_URL`` is
+    set in the environment, it overrides the wrapper's hardcoded base URL.
+    """
+
+    global _client
+    if _client is None:
+        client = Statbotics()
+        override = os.environ.get("STATBOTICS_API_URL")
+        if override:
+            client.BASE_URL = override.rstrip("/")
+        _client = client
+    return _client
+
+
+def reset_client() -> None:
+    """Reset the cached client. Intended for tests."""
+
+    global _client
+    _client = None

--- a/mcp/statbotics_mcp/client.py
+++ b/mcp/statbotics_mcp/client.py
@@ -8,11 +8,13 @@ variable, which is useful for pointing at a locally-running backend.
 from __future__ import annotations
 
 import os
+import threading
 from typing import Optional
 
 from statbotics import Statbotics
 
 _client: Optional[Statbotics] = None
+_client_lock = threading.Lock()
 
 
 def get_client() -> Statbotics:
@@ -20,15 +22,19 @@ def get_client() -> Statbotics:
 
     The instance is created lazily on first call. If ``STATBOTICS_API_URL`` is
     set in the environment, it overrides the wrapper's hardcoded base URL.
+    Initialization is guarded by a lock so HTTP-transport mode (which serves
+    concurrent requests) cannot race and create multiple instances.
     """
 
     global _client
     if _client is None:
-        client = Statbotics()
-        override = os.environ.get("STATBOTICS_API_URL")
-        if override:
-            client.BASE_URL = override.rstrip("/")
-        _client = client
+        with _client_lock:
+            if _client is None:
+                client = Statbotics()
+                override = os.environ.get("STATBOTICS_API_URL")
+                if override:
+                    client.BASE_URL = override.rstrip("/")
+                _client = client
     return _client
 
 
@@ -36,4 +42,5 @@ def reset_client() -> None:
     """Reset the cached client. Intended for tests."""
 
     global _client
-    _client = None
+    with _client_lock:
+        _client = None

--- a/mcp/statbotics_mcp/server.py
+++ b/mcp/statbotics_mcp/server.py
@@ -1,0 +1,283 @@
+"""FastMCP server exposing the public Statbotics API as MCP tools.
+
+Each tool is a thin wrapper around a method on the :class:`statbotics.Statbotics`
+client. Signatures, defaults, and tool descriptions mirror the underlying
+methods so the LLM-facing tool descriptions stay in sync with the published
+Python API.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
+from fastmcp import FastMCP
+from statbotics import Statbotics
+
+from .client import get_client
+
+mcp = FastMCP("statbotics")
+
+
+def _doc(method_name: str) -> str:
+    """Return the docstring of a Statbotics method for use as a tool description."""
+
+    return getattr(Statbotics, method_name).__doc__ or ""
+
+
+# ---------------------------------------------------------------------------
+# Teams
+# ---------------------------------------------------------------------------
+
+@mcp.tool(description=_doc("get_team"))
+def get_team(team: int, fields: List[str] = ["all"]) -> Dict[str, Any]:
+    return get_client().get_team(team=team, fields=fields)
+
+
+@mcp.tool(description=_doc("get_teams"))
+def get_teams(
+    country: Optional[str] = None,
+    state: Optional[str] = None,
+    district: Optional[str] = None,
+    active: Optional[bool] = True,
+    metric: str = "team",
+    ascending: Optional[bool] = None,
+    limit: int = 100,
+    offset: int = 0,
+    fields: List[str] = ["all"],
+) -> List[Dict[str, Any]]:
+    return get_client().get_teams(
+        country=country,
+        state=state,
+        district=district,
+        active=active,
+        metric=metric,
+        ascending=ascending,
+        limit=limit,
+        offset=offset,
+        fields=fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Years
+# ---------------------------------------------------------------------------
+
+@mcp.tool(description=_doc("get_year"))
+def get_year(year: int, fields: List[str] = ["all"]) -> Dict[str, Any]:
+    return get_client().get_year(year=year, fields=fields)
+
+
+@mcp.tool(description=_doc("get_years"))
+def get_years(
+    metric: str = "year",
+    ascending: Optional[bool] = None,
+    limit: int = 100,
+    offset: int = 0,
+    fields: List[str] = ["all"],
+) -> List[Dict[str, Any]]:
+    return get_client().get_years(
+        metric=metric,
+        ascending=ascending,
+        limit=limit,
+        offset=offset,
+        fields=fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Team-Years
+# ---------------------------------------------------------------------------
+
+@mcp.tool(description=_doc("get_team_year"))
+def get_team_year(
+    team: int, year: int, fields: List[str] = ["all"]
+) -> Dict[str, Any]:
+    return get_client().get_team_year(team=team, year=year, fields=fields)
+
+
+@mcp.tool(description=_doc("get_team_years"))
+def get_team_years(
+    team: Optional[int] = None,
+    year: Optional[int] = None,
+    country: Optional[str] = None,
+    state: Optional[str] = None,
+    district: Optional[str] = None,
+    metric: str = "team",
+    ascending: Optional[bool] = None,
+    limit: int = 100,
+    offset: int = 0,
+    fields: List[str] = ["all"],
+) -> List[Dict[str, Any]]:
+    return get_client().get_team_years(
+        team=team,
+        year=year,
+        country=country,
+        state=state,
+        district=district,
+        metric=metric,
+        ascending=ascending,
+        limit=limit,
+        offset=offset,
+        fields=fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+@mcp.tool(description=_doc("get_event"))
+def get_event(event: str, fields: List[str] = ["all"]) -> Dict[str, Any]:
+    return get_client().get_event(event=event, fields=fields)
+
+
+@mcp.tool(description=_doc("get_events"))
+def get_events(
+    year: Optional[int] = None,
+    country: Optional[str] = None,
+    state: Optional[str] = None,
+    district: Optional[str] = None,
+    type: Optional[Union[int, str]] = None,
+    week: Optional[int] = None,
+    metric: str = "year",
+    ascending: Optional[bool] = None,
+    limit: int = 100,
+    offset: int = 0,
+    fields: List[str] = ["all"],
+) -> List[Dict[str, Any]]:
+    return get_client().get_events(
+        year=year,
+        country=country,
+        state=state,
+        district=district,
+        type=type,
+        week=week,
+        metric=metric,
+        ascending=ascending,
+        limit=limit,
+        offset=offset,
+        fields=fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Team-Events
+# ---------------------------------------------------------------------------
+
+@mcp.tool(description=_doc("get_team_event"))
+def get_team_event(
+    team: int, event: str, fields: List[str] = ["all"]
+) -> Dict[str, Any]:
+    return get_client().get_team_event(team=team, event=event, fields=fields)
+
+
+@mcp.tool(description=_doc("get_team_events"))
+def get_team_events(
+    team: Optional[int] = None,
+    year: Optional[int] = None,
+    event: Optional[str] = None,
+    country: Optional[str] = None,
+    state: Optional[str] = None,
+    district: Optional[str] = None,
+    type: Optional[Union[int, str]] = None,
+    week: Optional[int] = None,
+    metric: str = "year",
+    ascending: Optional[bool] = None,
+    limit: int = 100,
+    offset: int = 0,
+    fields: List[str] = ["all"],
+) -> List[Dict[str, Any]]:
+    return get_client().get_team_events(
+        team=team,
+        year=year,
+        event=event,
+        country=country,
+        state=state,
+        district=district,
+        type=type,
+        week=week,
+        metric=metric,
+        ascending=ascending,
+        limit=limit,
+        offset=offset,
+        fields=fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Matches
+# ---------------------------------------------------------------------------
+
+@mcp.tool(description=_doc("get_match"))
+def get_match(match: str, fields: List[str] = ["all"]) -> Dict[str, Any]:
+    return get_client().get_match(match=match, fields=fields)
+
+
+@mcp.tool(description=_doc("get_matches"))
+def get_matches(
+    team: Optional[int] = None,
+    year: Optional[int] = None,
+    event: Optional[str] = None,
+    week: Optional[int] = None,
+    elims: Optional[bool] = None,
+    metric: str = "time",
+    ascending: Optional[bool] = None,
+    limit: int = 200,
+    offset: int = 0,
+    fields: List[str] = ["all"],
+) -> List[Dict[str, Any]]:
+    return get_client().get_matches(
+        team=team,
+        year=year,
+        event=event,
+        week=week,
+        elims=elims,
+        metric=metric,
+        ascending=ascending,
+        limit=limit,
+        offset=offset,
+        fields=fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Team-Matches
+# ---------------------------------------------------------------------------
+
+@mcp.tool(description=_doc("get_team_match"))
+def get_team_match(
+    team: int, match: str, fields: List[str] = ["all"]
+) -> Dict[str, Any]:
+    return get_client().get_team_match(team=team, match=match, fields=fields)
+
+
+@mcp.tool(description=_doc("get_team_matches"))
+def get_team_matches(
+    team: Optional[int] = None,
+    year: Optional[int] = None,
+    event: Optional[str] = None,
+    match: Optional[str] = None,
+    week: Optional[int] = None,
+    elims: Optional[bool] = None,
+    metric: str = "time",
+    ascending: Optional[bool] = None,
+    limit: int = 100,
+    offset: int = 0,
+    fields: List[str] = ["all"],
+) -> List[Dict[str, Any]]:
+    return get_client().get_team_matches(
+        team=team,
+        year=year,
+        event=event,
+        match=match,
+        week=week,
+        elims=elims,
+        metric=metric,
+        ascending=ascending,
+        limit=limit,
+        offset=offset,
+        fields=fields,
+    )
+
+
+__all__ = ["mcp"]

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -1,0 +1,107 @@
+"""Tests for the Statbotics MCP server."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, List
+
+import pytest
+
+from statbotics_mcp import client as client_module
+from statbotics_mcp.server import mcp
+
+EXPECTED_TOOLS = {
+    "get_team",
+    "get_teams",
+    "get_year",
+    "get_years",
+    "get_team_year",
+    "get_team_years",
+    "get_event",
+    "get_events",
+    "get_team_event",
+    "get_team_events",
+    "get_match",
+    "get_matches",
+    "get_team_match",
+    "get_team_matches",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_client():
+    client_module.reset_client()
+    yield
+    client_module.reset_client()
+
+
+def _list_tools():
+    return asyncio.run(mcp.list_tools())
+
+
+def test_all_tools_registered():
+    names = {t.name for t in _list_tools()}
+    assert EXPECTED_TOOLS.issubset(names), EXPECTED_TOOLS - names
+    assert len(EXPECTED_TOOLS & names) == 14
+
+
+def test_tool_descriptions_populated():
+    for tool in _list_tools():
+        if tool.name in EXPECTED_TOOLS:
+            assert tool.description, f"{tool.name} missing description"
+            assert "param" in tool.description.lower() or "return" in tool.description.lower()
+
+
+def test_tool_input_schema_has_expected_params():
+    by_name = {t.name: t for t in _list_tools()}
+    teams = by_name["get_teams"]
+    props = teams.parameters["properties"]
+    for expected in ("country", "state", "district", "active", "metric", "limit", "offset", "fields"):
+        assert expected in props, f"get_teams missing {expected}"
+
+
+def _stub_client(monkeypatch, payload):
+    class StubStatbotics:
+        BASE_URL = "https://api.statbotics.io/v3"
+
+        def get_team(self, team: int, fields: List[str]) -> Dict[str, Any]:
+            return {"team": team, "fields": fields, "payload": payload}
+
+        def get_teams(self, **kwargs):
+            return [{"kwargs": kwargs, "payload": payload}]
+
+    stub = StubStatbotics()
+    monkeypatch.setattr(client_module, "_client", stub)
+    return stub
+
+
+def test_get_team_tool_delegates_to_client(monkeypatch):
+    _stub_client(monkeypatch, "ok")
+    from statbotics_mcp.server import get_team
+
+    result = get_team(team=254)
+    assert result == {"team": 254, "fields": ["all"], "payload": "ok"}
+
+
+def test_get_teams_tool_passes_kwargs(monkeypatch):
+    _stub_client(monkeypatch, "ok")
+    from statbotics_mcp.server import get_teams
+
+    result = get_teams(state="CA", limit=5)
+    assert result[0]["kwargs"]["state"] == "CA"
+    assert result[0]["kwargs"]["limit"] == 5
+
+
+def test_env_var_overrides_base_url(monkeypatch):
+    monkeypatch.setenv("STATBOTICS_API_URL", "http://localhost:9999/v3")
+    client_module.reset_client()
+    client = client_module.get_client()
+    assert client.BASE_URL == "http://localhost:9999/v3"
+
+
+def test_no_env_var_uses_default(monkeypatch):
+    monkeypatch.delenv("STATBOTICS_API_URL", raising=False)
+    client_module.reset_client()
+    client = client_module.get_client()
+    assert client.BASE_URL == "https://api.statbotics.io/v3"


### PR DESCRIPTION
Adds a new top-level mcp/ package — a FastMCP-based MCP server wrapping the public Statbotics REST API at https://api.statbotics.io/v3.
   
   Highlights
   
   
    - 14 tools mirroring the statbotics Python client 1:1
    - stdio (default) and streamable-HTTP transports
    - Dockerfile + .dockerignore for toolchain-free local execution
    - Tests (7/7 passing), README with client config snippets (Claude Desktop, VS Code, Cursor, GitHub Copilot CLI, Docker), and a CLAUDE.md guide
   
   Commits
   
   
    1. feat(mcp) — the mcp/ package + Docker
    2. docs(mcp) — brainstorm notes
    3. docs — top-level README/CLAUDE.md pointers