### PR TITLE
Fix various UI performance or UI minor correctness issues

### DIFF
--- a/backend/src/db/functions/noteworthy_matches.py
+++ b/backend/src/db/functions/noteworthy_matches.py
@@ -55,14 +55,14 @@ def get_noteworthy_matches(
             matches.add_columns(
                 func.greatest(red_score_col, blue_score_col).label("max_score")
             )
-            .order_by(desc("max_score"), asc(MatchORM.time))  # type: ignore
+            .order_by(desc("max_score").nullslast(), asc(MatchORM.time))  # type: ignore
             .limit(30)
             .all()
         )
 
         combined_score_matches = (
             matches.add_columns((red_score_col + blue_score_col).label("sum_score"))  # type: ignore
-            .order_by(desc("sum_score"), asc(MatchORM.time))  # type: ignore
+            .order_by(desc("sum_score").nullslast(), asc(MatchORM.time))  # type: ignore
             .limit(30)
             .all()
         )
@@ -73,7 +73,7 @@ def get_noteworthy_matches(
                     "losing_score"
                 ),
             )
-            .order_by(desc("losing_score"), asc(MatchORM.time))  # type: ignore
+            .order_by(desc("losing_score").nullslast(), asc(MatchORM.time))  # type: ignore
             .limit(30)
             .all()
         )
@@ -86,7 +86,7 @@ def get_noteworthy_matches(
                         "max_auto_score"
                     )
                 )
-                .order_by(desc("max_auto_score"), asc("time"))  # type: ignore
+                .order_by(desc("max_auto_score").nullslast(), asc("time"))  # type: ignore
                 .limit(30)
                 .all()
             )
@@ -97,7 +97,7 @@ def get_noteworthy_matches(
                         "max_teleop_score"
                     )
                 )
-                .order_by(desc("max_teleop_score"), asc("time"))  # type: ignore
+                .order_by(desc("max_teleop_score").nullslast(), asc("time"))  # type: ignore
                 .limit(30)
                 .all()
             )
@@ -108,7 +108,7 @@ def get_noteworthy_matches(
                         "max_endgame_score"
                     )
                 )
-                .order_by(desc("max_endgame_score"), asc("time"))  # type: ignore
+                .order_by(desc("max_endgame_score").nullslast(), asc("time"))  # type: ignore
                 .limit(30)
                 .all()
             )

--- a/frontend/src/api/storage.tsx
+++ b/frontend/src/api/storage.tsx
@@ -37,19 +37,14 @@ export function decompress(buffer: any) {
   return data;
 }
 
-async function query(
+const inFlight: { [storageKey: string]: Promise<any> } = {};
+
+async function fetchAndStore(
   storageKey: string,
   apiPath: string,
   checkBucket: boolean,
-  minLength: number,
   expiry: number
 ) {
-  const cacheData = await getWithExpiry(storageKey);
-  if (cacheData && (minLength === 0 || cacheData?.length > minLength)) {
-    log(`Used Local Storage: ${storageKey}`);
-    return cacheData;
-  }
-
   const start = performance.now();
 
   let buffer = null;
@@ -83,6 +78,28 @@ async function query(
     await setWithExpiry(storageKey, buffer, expiry);
     return buffer;
   }
+}
+
+async function query(
+  storageKey: string,
+  apiPath: string,
+  checkBucket: boolean,
+  minLength: number,
+  expiry: number
+) {
+  const cacheData = await getWithExpiry(storageKey);
+  if (cacheData && (minLength === 0 || cacheData?.length > minLength)) {
+    log(`Used Local Storage: ${storageKey}`);
+    return cacheData;
+  }
+
+  if (!inFlight[storageKey]) {
+    inFlight[storageKey] = fetchAndStore(storageKey, apiPath, checkBucket, expiry).finally(() => {
+      delete inFlight[storageKey];
+    });
+  }
+
+  return inFlight[storageKey];
 }
 
 export default query;

--- a/frontend/src/pages/match/[match_id].tsx
+++ b/frontend/src/pages/match/[match_id].tsx
@@ -23,7 +23,7 @@ const InnerPage = () => {
 
   useEffect(() => {
     const fetchMatchData = async () => {
-      if (!match_id || data) return;
+      if (!match_id || data?.match?.key == match_id) return;
 
       try {
         const matchData = await getMatch(match_id as string);

--- a/frontend/src/pagesContent/event/[event_id]/simulation.tsx
+++ b/frontend/src/pagesContent/event/[event_id]/simulation.tsx
@@ -137,7 +137,7 @@ const SimulationSection = ({ eventId, data }: { eventId: string; data: EventData
       rank: i + 1,
       num: teamEvent.team,
       team: teamEvent?.team_name,
-      epa: round(teamEvent?.epa?.total_points?.mean ?? 0, 1),
+      epa: round(teamEvent?.epa?.breakdown?.total_points ?? 0, 1),
       rankMean: rankMean[teamEvent.team] ? round(rankMean[teamEvent.team], 2) : "",
       rank5: rank5[teamEvent.team] ? round(rank5[teamEvent.team], 2) : "",
       rank50: rank50[teamEvent.team] ? round(rank50[teamEvent.team], 2) : "",
@@ -158,7 +158,7 @@ const SimulationSection = ({ eventId, data }: { eventId: string; data: EventData
       return {
         num: teamEvent.team,
         team: teamEvent?.team_name,
-        epa: round(teamEvent?.epa?.total_points?.mean ?? 0, 1),
+        epa: round(teamEvent?.epa?.breakdown?.total_points ?? 0, 1),
         rankMean: rankMean[teamEvent.team] ? round(rankMean[teamEvent.team], 2) : "",
         RPMean: RPMean[teamEvent.team] ? round(RPMean[teamEvent.team], 2) : "",
         ...probsObj,

--- a/frontend/src/pagesContent/event/[event_id]/worker.ts
+++ b/frontend/src/pagesContent/event/[event_id]/worker.ts
@@ -570,7 +570,7 @@ async function _strengthOfSchedule(data: EventData, simCount: number, postEvent:
       currTeamOpponents.length;
 
     const deltaEPA = epaAvg + 2 * avgPartnerEPA - 3 * avgOpponentEPA;
-    const distrib = Gaussian(0, (epaSd * epaSd * 5) / N);
+    const distrib = Gaussian(0, (epaSd * epaSd * 5) / N || 1e-9);
     const epaPercentile = 1 - distrib.cdf(deltaEPA);
 
     const overallPercentile = (rankPercentile + rpPercentile + epaPercentile) / 3;

--- a/frontend/src/pagesContent/match/[match_id]/imageRow.tsx
+++ b/frontend/src/pagesContent/match/[match_id]/imageRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import Image from "next/image";
 
@@ -10,8 +10,10 @@ import { getMediaUrls } from "../../../utils";
 const ImageRow = ({ data }: { data: MatchData }) => {
   const [media, setMedia] = useState<string[] | null>(null);
 
-  const reverseBlue = [...data?.match?.alliances?.blue?.team_keys].reverse();
-  const teams = data?.match?.alliances?.red?.team_keys?.concat(reverseBlue);
+  const teams = useMemo(() => {
+    const reverseBlue = [...data?.match?.alliances?.blue?.team_keys].reverse();
+    return data?.match?.alliances?.red?.team_keys?.concat(reverseBlue);
+  }, [data]);
   const year = data.year.year;
 
   useEffect(() => {


### PR DESCRIPTION

This PR fixes six distinct performance or minor correctness UI issues.  Verified with a real browser against a local rig (CockroachDB + fake-gcs + full 2026 season, 3724 teams / 215 events / 18372 matches).

## 1. Match page: infinite media-request loop

**Symptom.** On every `/match/{key}` page the browser fired an endless stream of requests to TBA's `/team/frc{N}/media/{year}` endpoint — measured **~11,747 requests in 5 seconds** on a single open page. Every production visitor has been silently doing this to TBA.

**Root cause.** `frontend/src/pagesContent/match/[match_id]/imageRow.tsx:13-14` recomputed the `teams` array with `.concat()` on every render, producing a new array reference each time. The `useEffect(..., [teams, year])` at line 19 then called `getMediaUrls` and `setMedia`, whose state update re-rendered the component, produced a fresh `teams` reference, and re-triggered the effect — an unbounded loop.

**Fix.** Wrap `teams` in `useMemo(..., [data])` so its reference is stable across renders and the effect runs only when the underlying match data changes.

## 2. Match page: Previous/Next buttons don't update the page

**Symptom.** Clicking the prev/next arrows changed the URL and document title but left the displayed match unchanged.

**Root cause.** `frontend/src/pages/match/[match_id].tsx:26` guarded the fetch with `if (!match_id || data) return;`. Because Next.js reuses the same component instance across `/match/*` route changes, `data` was already truthy from the previous match, so the guard short-circuited and never fetched the new match.

**Fix.** Compare the loaded key against the route — `if (!match_id || data?.match?.key == match_id) return;` — matching the existing pattern in `pages/event/[event_id].tsx:25`. The effect already depends on `[match_id, data]`, so it now refetches when the route changes and skips redundant fetches once the correct match is loaded.

## 3. Strength of Schedule renders blank (or NaN) when pre-event EPAs are identical

**Symptom.** On the **Strength of Schedule** tab the RP/Rank/EPA/Composite score columns fail to populate. Two manifestations: score columns entirely **blank**, or **`NaN`** in EPA Score and Composite Score.

**Root cause.** `strengthOfSchedule()` (in `frontend/src/pagesContent/event/[event_id]/worker.ts`) runs a "Before Event" pass that computes `epaSd`, the standard deviation of every team's pre-event start EPA, and builds a Gaussian to score EPA-based schedule strength:

```
const distrib = Gaussian(0, (epaSd * epaSd * 5) / N);
```

Early in a season — before ratings diverge — every team at an event shares the same cold-start EPA, so `epaSd` is `0`, the variance is `0`, and `gaussian` throws `Error('Variance must be > 0')`. Because the worker's message handler calls `strengthOfSchedule(...)` without `await`/`catch`, the throw becomes a silent unhandled promise rejection: no message is posted and the table stays blank. A floating-point variant produces the `NaN` symptom — with all EPAs equal, `Math.sqrt(sum(x^2)/n - avg^2)` occasionally takes the root of a tiny *negative* rounding residue, so `epaSd` is `NaN`, `gaussian` does not throw (`NaN <= 0` is false), and every EPA percentile is `NaN`. Both are the same degeneracy: EPA carries no schedule signal when all ratings are identical.

**Fix.** Floor the variance with `|| 1e-9`, which treats both `0` and `NaN` as falsy and substitutes a negligible positive variance; with `deltaEPA == 0` the CDF at the mean is `0.5`, so every team gets a neutral `0.5` EPA percentile — the correct answer when EPA is non-informative. Any real positive variance passes through untouched. Matches the `|| 0` fallback idiom already used throughout this worker.

## 4. Simulation tab shows EPA 0 for every team

**Symptom.** On the **Simulation** tab the EPA column reads `0` for all teams (the predicted ranks, RP means, and percentiles are correct).

**Root cause.** `frontend/src/pagesContent/event/[event_id]/simulation.tsx` reads the team EPA as `teamEvent.epa.total_points.mean`. That matches the `APITeamEvent` TypeScript type, but not the runtime shape: the backend serves `epa.total_points` as a plain number, so `.mean` is `undefined` and `?? 0` renders `0`.

**Fix.** Read `epa.breakdown.total_points` — the same field the SOS tab and the simulation worker already use — which is present at runtime.

## 5. Noteworthy matches rank a null/placeholder match incorrectly

**Symptom.** `/v3/site/noteworthy_matches/2026` returned a 0/null-score, fully-DQed placeholder match (`2026txmca_sf6m1`) at the top of "Highest Clean Scores" (and the other lists), ahead of real high scores.

**Root cause.** `backend/src/db/functions/noteworthy_matches.py` — the lists `order_by(desc(...))` without specifying null placement. CockroachDB orders NULLs first under `DESC`. For 2016+ the sort uses the `no_foul` columns; a match with no clean result on either alliance yields `greatest(...) = NULL` (and `sum = NULL` for combined), so it sorts to the top. (The value only surfaces on a NULLS-FIRST-defaulting DB, which is why it appears on staging.)

**Fix.** Add `.nullslast()` to every noteworthy `order_by`. Null-result matches fall past the top-30 cutoff; real high-scoring matches rank first; legitimate single-alliance-DQ matches still rank by their scoring alliance.

## 6. Every blob/API resource fetched twice on team pages

**Symptom.** On `/team/*`, each event/team blob was downloaded exactly twice per page load (observed on the production build, so not a StrictMode artifact).

**Root cause.** `frontend/src/api/storage.tsx` `query()` had no in-flight dedup. Several components request the same resource concurrently; each awaits `getWithExpiry()`, all miss IndexedDB (nothing is written until a fetch resolves), and all issue their own fetch.

**Fix.** Add a module-level in-flight promise map keyed by `storageKey`. Concurrent callers for the same key share one fetch; the entry clears once it settles. The fetch body is extracted into `fetchAndStore` unchanged.

## Verification

- **Match page:** after the fix the steady-state media-request count is `0` (was ~11.7k/5s), and prev/next navigation updates the displayed match (Qual 43 ↔ Qual 44) with the arrows re-pointing correctly.
- **Strength of Schedule:** `epaSd == 0` event — before: Gaussian throws, SOS blank; after: all columns populate (EPA Score `0.5`). `epaSd == NaN` (float rounding) event — before: EPA/Composite `NaN`; after: populate (EPA Score `0.5`). Event with a genuine non-zero EPA spread: EPA percentile `0.387` before and after — unchanged (the fix is inert on the non-degenerate path).
- **Simulation:** EPA column `0` before, real per-team EPA after; predicted-rank distributions unchanged and still vary run-to-run.
- **Noteworthy:** simulating staging's NULLS-FIRST ordering, `2026txmca_sf6m1`/`_sf9m1` ranked first or second above the real 964-point match; with the patched query, `2026dal_f1m1` (964) is first across all six lists and the placeholder is gone.
- **Duplicate fetches:** each event/team blob downloaded once per page load after the dedup (was twice).

