### PR TITLE
Fix minor correctness issues for older years

### DIFF
--- a/backend/src/tba/read_tba.py
+++ b/backend/src/tba/read_tba.py
@@ -217,10 +217,14 @@ def get_event_matches(
                 winner = MatchWinner.RED
             elif raw_winner == "blue":
                 winner = MatchWinner.BLUE
+            elif red_score > blue_score:
+                winner = MatchWinner.RED
+            elif blue_score > red_score:
+                winner = MatchWinner.BLUE
             else:
                 winner = MatchWinner.TIE
 
-            if year == 2015 and match["comp_level"] != "f":
+            if year == 2015 and match["comp_level"] == "qm":
                 winner = None
 
         red_teams = [team[3:] for team in red_teams]

--- a/frontend/src/pagesContent/match/[match_id]/table.tsx
+++ b/frontend/src/pagesContent/match/[match_id]/table.tsx
@@ -201,13 +201,17 @@ const PageMatchTable = ({ data }: { data: MatchData }) => {
     const red2 = component.red2 !== null ? round(component.red2 ?? 0, digits) : "N/A";
     const red3 = component.red3 !== null ? round(component.red3 ?? 0, digits) : "N/A";
     const redTotal =
-      component.redTotal !== null ? round(component.redTotal ?? 0, digits === 2 ? 2 : 0) : "N/A";
+      component.redTotal !== null && !Number.isNaN(component.redTotal)
+        ? round(component.redTotal ?? 0, digits === 2 ? 2 : 0)
+        : "N/A";
     const redActual = component.redActual !== null ? round(component.redActual ?? 0, 0) : "-";
     const blue1 = component.blue1 !== null ? round(component.blue1 ?? 0, digits) : "N/A";
     const blue2 = component.blue2 !== null ? round(component.blue2 ?? 0, digits) : "N/A";
     const blue3 = component.blue3 !== null ? round(component.blue3 ?? 0, digits) : "N/A";
     const blueTotal =
-      component.blueTotal !== null ? round(component.blueTotal ?? 0, digits === 2 ? 2 : 0) : "N/A";
+      component.blueTotal !== null && !Number.isNaN(component.blueTotal)
+        ? round(component.blueTotal ?? 0, digits === 2 ? 2 : 0)
+        : "N/A";
     const blueActual = component.blueActual !== null ? round(component.blueActual ?? 0, 0) : "-";
     return {
       name: component.name,

--- a/frontend/src/pagesContent/teams/tabs.tsx
+++ b/frontend/src/pagesContent/teams/tabs.tsx
@@ -64,8 +64,8 @@ const Tabs = ({
             year >= 2016 && "Teleop",
             year >= 2016 && "Endgame",
             year >= 2016 && "Auto + Endgame",
-            year >= 2016 && `${RP_NAMES[year][0]}`,
-            year >= 2016 && `${RP_NAMES[year][1]}`,
+            RP_NAMES[year] && `${RP_NAMES[year][0]}`,
+            RP_NAMES[year] && `${RP_NAMES[year][1]}`,
             "Wins",
             "Win Rate",
           ].filter(Boolean) as string[]


### PR DESCRIPTION
Three independent minor correctness fixes surfaced by a full staging audit performed by Claude Code. Each is small and self-contained.   Verified against a local rig (CockroachDB + fake-gcs + full 2026 season, 3724 teams / 215 events / 18372 matches).

## 1. Team pages bubble chart `/teams?year=2021` unhandled exception
`RP_NAMES` (`frontend/src/constants.tsx`) has no `2021` key (2021 had no traditional season). The teams Bubble Chart `columnOptions` dereferenced `RP_NAMES[year][0]` for any `year >= 2016`, throwing a `TypeError` at render → "Application error: a client-side exception has occurred". `/events?year=2021` already degrades gracefully; `/teams` now does too.

Fix: guard the two ranking-point columns on `RP_NAMES[year]` instead of `year >= 2016`, so a no-season year drops those columns and falls through to the normal no-data state.

## 2. Match pages display literal "NaN" in predicted component cells for pre-2016 match pages
On pre-component-era matches (2002–2015, e.g. `/match/2015casj_qm1`) the Predicted Auto/Teleop/Endgame/Fouls alliance totals sum per-team component EPAs that don't exist for those years, producing `NaN`, which rendered as the literal text "NaN". Sibling cells already use "N/A".

Fix: treat a `NaN` alliance total the same as `null` and render "N/A".

## 3. Winner incorrect for 2015 elimination matches
`get_event_matches` (`backend/src/tba/read_tba.py`) forced `winner = None` for every 2015 match that wasn't a Final, and fell back to `TIE` (never a score comparison) when TBA's `winning_alliance` was absent. 2015 QF/SF elims — which did have winners — came back winner-less (14/16 elims on `2015new`), breaking win/loss records, event prediction accuracy, and the match "Actual Winner" display. 2015 quals (Recycle Rush, cooperative) legitimately have no winner.

Fix: when `winning_alliance` is absent, derive the winner from the alliance scores; restrict the 2015 winner-less rule to quals (`comp_level == "qm"`) only.

Verified against live TBA for `2015new`/`2015casj`: before → QF 8/8 + SF 6/6 winner-less; after → all elim winners derived from score, all quals still winner-less.

